### PR TITLE
Upgrade to .Net 8 and newest NuGet packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Install dependencies
         run: dotnet restore ProseMirror.Model.sln -s https://api.nuget.org/v3/index.json

--- a/src/ProseMirror.Model.Example/ProseMirror.Model.Example.csproj
+++ b/src/ProseMirror.Model.Example/ProseMirror.Model.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProseMirror.Model/ProseMirror.Model.csproj
+++ b/src/ProseMirror.Model/ProseMirror.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.4.0</Version>
     <Authors>Xavier</Authors>
     <Company>Holoon</Company>

--- a/src/ProseMirror.Serializer/ProseMirror.Serializer.csproj
+++ b/src/ProseMirror.Serializer/ProseMirror.Serializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	  <Version>2.2.0</Version>
 	  <Authors>Xavier</Authors>
 	  <Company>Holoon</Company>
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Holoon.HtmlBuilder" Version="1.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Holoon.HtmlBuilder" Version="1.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Analogous to https://github.com/Holoon/HtmlBuilder/pull/3:
- Upgrades the target framework to .Net 8. Not .Net 9, because .Net 8 is an LTS release
- Upgrades both referenced NuGet packages to the latest version